### PR TITLE
Add 'line_length_limit' configuration field to 'docutils.frontend.Values'

### DIFF
--- a/pospell.py
+++ b/pospell.py
@@ -149,6 +149,7 @@ def strip_rst(line):
             "tab_width": 8,
             "trim_footnote_reference_space": None,
             "syntax_highlight": "long",
+            "line_length_limit": 10000,
         }
     )
     stderr_stringio = io.StringIO()


### PR DESCRIPTION
The new 0.17 version of docutils has added the field [`line_length_limit`](https://docutils.sourceforge.io/docs/user/config.html#line-length-limit) to `docutils.frontend.Values`. I'm getting the next error trying to execute the example of the README with docutils v0.17:

```
$ pospell --language fr *.po
Traceback (most recent call last):
  File "/.../venv/bin/pospell", line 8, in <module>
    sys.exit(main())
  File "/.../venv/lib/python3.8/site-packages/pospell.py", line 413, in main
    errors = spell_check(
  File "/.../venv/lib/python3.8/site-packages/pospell.py", line 312, in spell_check
    texts_for_hunspell[po_file] = po_to_text(str(po_file), drop_capitalized)
  File "/.../venv/lib/python3.8/site-packages/pospell.py", line 206, in po_to_text
    buffer.append(clear(strip_rst(entry.msgstr), drop_capitalized, po_path=po_path))
  File "/.../venv/lib/python3.8/site-packages/pospell.py", line 139, in strip_rst
    parser.parse(line, document)
  File "/.../venv/lib/python3.8/site-packages/docutils/parsers/rst/__init__.py", line 196, in parse
    if len(line) > self.document.settings.line_length_limit:
AttributeError: 'Values' object has no attribute 'line_length_limit'
```

I've tested the change with docutils v0.16 and also works as expected.