### PR TITLE
add line_length_limit setting

### DIFF
--- a/pospell.py
+++ b/pospell.py
@@ -142,6 +142,7 @@ def strip_rst(line):
             "id_prefix": "",
             "auto_id_prefix": "id",
             "pep_references": None,
+            "line_length_limit": 10000,
             "pep_base_url": "http://www.python.org/dev/peps/",
             "pep_file_url_template": "pep-%04d",
             "rfc_references": None,


### PR DESCRIPTION
fixes crash with docutils 0.17

see https://github.com/live-clones/docutils/commit/9cb4a09dce077f479925bb7195b3f9a7a280a5f6