### PR TITLE
Ignore deleted files discovered by GIT using '--modified' option

### DIFF
--- a/pospell.py
+++ b/pospell.py
@@ -441,7 +441,7 @@ def main():
     )
     if args.modified:
         git_status = subprocess.check_output(
-            ["git", "status", "--porcelain"], encoding="utf-8"
+            ["git", "status", "--porcelain", "--no-renames"], encoding="utf-8"
         )
         git_status_lines = [
             line.split(maxsplit=2) for line in git_status.split("\n") if line
@@ -449,7 +449,7 @@ def main():
         args.po_file.extend(
             Path(filename)
             for status, filename in git_status_lines
-            if filename.endswith(".po")
+            if filename.endswith(".po") and status != "D"
         )
     try:
         errors = spell_check(


### PR DESCRIPTION
As [was fixed in powrap](https://github.com/AFPy/powrap/pull/86), ignore deleted files discovered by GIT when the `--modified` option is used.

To reproduce this, create a basic `.po` file, do a commit, rename the file and execute pospell using `--modified` option. In this case, renaming a file from `foo.po` to `bar.po`, the output of `git status --porcelain` is:

```
 D foo.po
?? bar.po
```

So the same fix is working for this case also.