### PR TITLE
Allow using only --glob without further po_files

### DIFF
--- a/pospell.py
+++ b/pospell.py
@@ -292,7 +292,7 @@ def parse_args():
         print("Error: don't provide both --drop-capitalized AND --no-drop-capitalized.")
         parser.print_help()
         sys.exit(1)
-    if not args.po_file and not args.modified:
+    if not args.po_file and not args.modified and not args.glob:
         parser.print_help()
         sys.exit(1)
     return args


### PR DESCRIPTION
At the moment pospell complains if invoked with a --glob pattern but
without any other po_files in the command line. This is a problem only
with the check, as the code is ready to handle the situation. To bypass
this problem, one *needs* to pass a po_file in the command-line as well,
even if the glob pattern contains it.

This commit adjusts the condition that checks that input files have been
somehow specified to consider --glob as a source of input files.

Signed-off-by: Rodrigo Tobar <rtobar@icrar.org>